### PR TITLE
Port to 1.16.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.21
-loader_version=0.8.9+build.203
+minecraft_version=1.16.2
+yarn_mappings=1.16.2+build.6
+loader_version=0.9.1+build.205
 
 #Fabric api
-fabric_version=0.14.1+build.372-1.16
-libgui_version=2.2.0+1.16.1
+fabric_version=0.17.2+build.396-1.16
+libgui_version=3.0.0-beta.1+1.16.2-rc2
 # Mod Properties
 mod_version=1.4.0+mc.1.16.2
 maven_group=io.github.franiscoder

--- a/src/main/java/io/github/franiscoder/tacocraft/init/ModGen.java
+++ b/src/main/java/io/github/franiscoder/tacocraft/init/ModGen.java
@@ -1,45 +1,73 @@
 package io.github.franiscoder.tacocraft.init;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import io.github.franiscoder.tacocraft.TacoCraft;
 import io.github.franiscoder.tacocraft.world.CornFieldFeature;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.BuiltinRegistries;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
+import net.minecraft.world.biome.BuiltinBiomes;
 import net.minecraft.world.gen.GenerationStep;
 import net.minecraft.world.gen.decorator.ChanceDecoratorConfig;
 import net.minecraft.world.gen.decorator.Decorator;
+import net.minecraft.world.gen.decorator.NopeDecoratorConfig;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
 
 public class ModGen {
 
     public static void register() {
-        Registry.register(
+
+        CornFieldFeature cornFeature = Registry.register(
                 Registry.FEATURE,
                 TacoCraft.id("feature"),
                 new CornFieldFeature()
         );
 
-        Biomes.PLAINS.addFeature(
-                GenerationStep.Feature.TOP_LAYER_MODIFICATION,
-                new CornFieldFeature()
-                        .configure(new DefaultFeatureConfig())
-                        .createDecoratedFeature(Decorator.CHANCE_HEIGHTMAP
-                                .configure(new ChanceDecoratorConfig(100)))
-        );
-        Biomes.SUNFLOWER_PLAINS.addFeature(
-                GenerationStep.Feature.TOP_LAYER_MODIFICATION,
-                new CornFieldFeature()
-                        .configure(new DefaultFeatureConfig())
-                        .createDecoratedFeature(Decorator.CHANCE_HEIGHTMAP
-                                .configure(new ChanceDecoratorConfig(200)))
-        );
-        Biomes.SAVANNA.addFeature(
-                GenerationStep.Feature.TOP_LAYER_MODIFICATION,
-                new CornFieldFeature()
-                        .configure(new DefaultFeatureConfig())
-                        .createDecoratedFeature(Decorator.CHANCE_HEIGHTMAP
-                                .configure(new ChanceDecoratorConfig(200)))
-        );
+        ConfiguredFeature<?, ?> configuredFeature = cornFeature
+                                                .configure(new DefaultFeatureConfig())
+                                                .decorate(Decorator.HEIGHTMAP
+                                                        .configure(new NopeDecoratorConfig()).applyChance(100));
+
+        addCorn(configuredFeature, Biomes.PLAINS);
+        addCorn(configuredFeature, BuiltinRegistries.BIOME.get(BuiltinBiomes.SUNFLOWER_PLAINS));
+        addCorn(configuredFeature, BuiltinRegistries.BIOME.get(BuiltinBiomes.SAVANNA));
     }
 
+    private static void addCorn(ConfiguredFeature<?, ?> configuredFeature, Biome biome) {
+        addFeature(biome,TacoCraft.id("feature"), GenerationStep.Feature.TOP_LAYER_MODIFICATION, configuredFeature);
+    }
 
+    private static void addFeature(Biome biome, Identifier identifier, GenerationStep.Feature feature, ConfiguredFeature<?, ?> configuredFeature) {
+        List<List<Supplier<ConfiguredFeature<?, ?>>>> features = biome.getGenerationSettings().getFeatures();
+
+        int stepIndex = feature.ordinal();
+
+        while (features.size() <= stepIndex) {
+            features.add(Lists.newArrayList());
+        }
+
+        List<Supplier<ConfiguredFeature<?, ?>>> stepList = features.get(feature.ordinal());
+        if (stepList instanceof ImmutableList) {
+            features.set(feature.ordinal(), stepList = new ArrayList<>(stepList));
+        }
+
+        if (!BuiltinRegistries.CONFIGURED_FEATURE.getKey(configuredFeature).isPresent()) {
+            if (BuiltinRegistries.CONFIGURED_FEATURE.getOrEmpty(identifier).isPresent()) {
+                ConfiguredFeature<?,?> b = BuiltinRegistries.CONFIGURED_FEATURE.getOrEmpty(identifier).get();
+                throw new RuntimeException("Duplicate feature: " + identifier.toString());
+            }
+
+            BuiltinRegistries.add(BuiltinRegistries.CONFIGURED_FEATURE, identifier, configuredFeature);
+        }
+
+        stepList.add(() -> configuredFeature);
+    }
 }

--- a/src/main/java/io/github/franiscoder/tacocraft/mixins/MixinGenerationSettings.java
+++ b/src/main/java/io/github/franiscoder/tacocraft/mixins/MixinGenerationSettings.java
@@ -1,0 +1,37 @@
+package io.github.franiscoder.tacocraft.mixins;
+
+import net.minecraft.world.biome.GenerationSettings;
+import net.minecraft.world.gen.GenerationStep;
+import net.minecraft.world.gen.carver.ConfiguredCarver;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
+import net.minecraft.world.gen.feature.ConfiguredStructureFeature;
+import net.minecraft.world.gen.surfacebuilder.ConfiguredSurfaceBuilder;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * @author RebornCore https://github.com/TechReborn/RebornCore/blob/56c193ca3918f2efb9d03af3145b5076f28fec58/src/main/java/reborncore/mixin/common/MixinGenerationSettings.java
+ */
+@Mixin(GenerationSettings.class)
+public class MixinGenerationSettings {
+
+    @Shadow
+    @Final
+    @Mutable
+    private List<List<Supplier<ConfiguredFeature<?, ?>>>> features;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void init(Supplier<ConfiguredSurfaceBuilder<?>> surfaceBuilder, Map<GenerationStep.Carver, List<Supplier<ConfiguredCarver<?>>>> carvers, List<List<Supplier<ConfiguredFeature<?, ?>>>> features, List<Supplier<ConfiguredStructureFeature<?, ?>>> structureFeatures, CallbackInfo info){
+        this.features = new ArrayList<>(features);
+    }
+}

--- a/src/main/java/io/github/franiscoder/tacocraft/world/CornFieldFeature.java
+++ b/src/main/java/io/github/franiscoder/tacocraft/world/CornFieldFeature.java
@@ -8,6 +8,7 @@ import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Heightmap;
 import net.minecraft.world.ServerWorldAccess;
+import net.minecraft.world.StructureWorldAccess;
 import net.minecraft.world.gen.StructureAccessor;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
@@ -21,8 +22,8 @@ public class CornFieldFeature extends Feature<DefaultFeatureConfig> {
     }
 
     @Override
-    public boolean generate(ServerWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator generator, Random random, BlockPos pos, DefaultFeatureConfig config) {
-        BlockPos topPos1 = world.getTopPosition(Heightmap.Type.OCEAN_FLOOR_WG, pos);
+    public boolean generate(StructureWorldAccess world, ChunkGenerator chunkGenerator, Random random, BlockPos blockPos, DefaultFeatureConfig featureConfig) {
+        BlockPos topPos1 = world.getTopPosition(Heightmap.Type.OCEAN_FLOOR_WG, blockPos);
         world.setBlockState(topPos1.down(), Blocks.FARMLAND.getDefaultState().with(FarmlandBlock.MOISTURE, 7), 3);
         world.setBlockState(topPos1, ModBlocks.CORN_BLOCK.getDefaultState().with(CornBlock.AGE, 7).with(CornBlock.HALF, DoubleBlockHalf.LOWER), 3);
         world.setBlockState(topPos1.up(), ModBlocks.CORN_BLOCK.getDefaultState().with(CornBlock.AGE, 7).with(CornBlock.HALF, DoubleBlockHalf.UPPER), 3);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
       "io.github.franiscoder.tacocraft.TacoCraftClient"
     ]
   },
+  "mixins": [
+    "tacocraft.mixins.json"
+  ],
   "custom": {
     "modupdater": {
       "strategy": "json",

--- a/src/main/resources/tacocraft.mixins.json
+++ b/src/main/resources/tacocraft.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "io.github.franiscoder.tacocraft.mixins",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MixinGenerationSettings"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
It seems like how the datapack system is set up I can't add features using Json. I can only replace the entire biome. So I found that TechReborn is using this method and adapted it to work for TacoCraft. The rest already seemed to work fine. It should be identical to the previous generation :)